### PR TITLE
Provide ActivatedRouteSnapshot in confirmChanges function

### DIFF
--- a/libs/dirty-check-forms/src/lib/dirty-check.guard.ts
+++ b/libs/dirty-check-forms/src/lib/dirty-check.guard.ts
@@ -28,11 +28,11 @@ export abstract class DirtyCheckGuard implements CanDeactivate<DirtyComponent> {
         if (isDirty === false) {
           return of(true);
         }
-        return toObservable(this.confirmChanges());
+        return toObservable(this.confirmChanges(currentRoute));
       }),
       take(1)
     );
   }
 
-  abstract confirmChanges(): Observable<boolean> | boolean;
+  abstract confirmChanges(currentRoute: ActivatedRouteSnapshot): Observable<boolean> | boolean;
 }


### PR DESCRIPTION
To avoid [this issue](https://stackoverflow.com/questions/44030261/angular-how-to-make-candeactivate-work-correctly-with-the-use-of-location-back) related to angular location.back() method, the currentRoute must be available in confirmChanges function. 
So we can write something like: 

```typescript
  confirmChanges(currentRoute: ActivatedRouteSnapshot): Observable<boolean> | boolean {
    return this.helperDialogs.confirm($localize`Confirm`, $localize`You have unsaved changes. Are you sure you want to leave?`)
    .pipe(
      tap((ok) => {
        if (!ok) {
          const currentUrlTree = this.router.createUrlTree([], currentRoute);
          const currentUrl = currentUrlTree.toString();
          this.location.go(currentUrl)
        }
      })
    );
```

