### PR TITLE
Avoid using the global window

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Call the `dirtyCheck` function, which accepts three arguments:
 3. Config:  
   - `debounce` - debounce time of `valueChanges`. Defaults to 300  
   - `withDisabled` - whether to include disable fields (by using control's `getRawValue`) or not. Defaults to `true`. 
-  - `window` - global `Window` object to handle `onbeforeunload` event. Defaults to `undefined`.
+  - `useBeforeunloadEvent` - enable or disable `onbeforeunload` event handling. Defaults to `true`.
 
 The function returns an `Observable<boolean>`, which notifies whether the form is dirty. Furthermore, it also hooks on the browser's `beforeunload` event to confirm upon refreshing/closing the tab when needed.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Call the `dirtyCheck` function, which accepts three arguments:
 3. Config:  
   - `debounce` - debounce time of `valueChanges`. Defaults to 300  
   - `withDisabled` - whether to include disable fields (by using control's `getRawValue`) or not. Defaults to `true`. 
+  - `window` - global `Window` object to handle `onbeforeunload` event. Defaults to `undefined`.
 
 The function returns an `Observable<boolean>`, which notifies whether the form is dirty. Furthermore, it also hooks on the browser's `beforeunload` event to confirm upon refreshing/closing the tab when needed.
 

--- a/libs/dirty-check-forms/src/lib/dirty-check.ts
+++ b/libs/dirty-check-forms/src/lib/dirty-check.ts
@@ -13,13 +13,14 @@ import { equal as isEqual } from './is-equal';
 interface DirtyCheckConfig {
   debounce?: number;
   withDisabled?: boolean;
-  window?: Window;
+  useBeforeunloadEvent?: boolean;
 }
 
 function mergeConfig(config: DirtyCheckConfig): DirtyCheckConfig {
   return {
     debounce: 300,
     withDisabled: true,
+    useBeforeunloadEvent: true,
     ...config,
   };
 }
@@ -39,7 +40,7 @@ export function dirtyCheck<U>(
   source: Observable<U>,
   config: DirtyCheckConfig = {}
 ): Observable<boolean> {
-  const { debounce, withDisabled, window } = mergeConfig(config);
+  const { debounce, withDisabled, useBeforeunloadEvent } = mergeConfig(config);
   const value = () => getControlValue(control, withDisabled);
   const valueChanges$ = merge(
     defer(() => of(value())),
@@ -60,7 +61,7 @@ export function dirtyCheck<U>(
       shareReplay({ bufferSize: 1, refCount: true })
     );
 
-    if (window) {
+    if (useBeforeunloadEvent) {
       observer.add(
         fromEvent(window, 'beforeunload')
           .pipe(withLatestFrom(isDirty$))


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: https://github.com/ngneat/dirty-check-forms/issues/13

## What is the new behavior?

`window ` global object is included in config.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No